### PR TITLE
Fix warnings when building on Elixir 1.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: elixir
 elixir:
-- 1.3.4
+  - 1.3.4
+  - 1.4.0
 script:
-- env MIX_ENV=test mix coveralls.travis
+  - env MIX_ENV=test mix coveralls.travis

--- a/lib/optimus.ex
+++ b/lib/optimus.ex
@@ -103,10 +103,10 @@ defmodule Optimus do
         optimus |> Optimus.Title.title  |> put_lines
         System.halt(0)
       :help ->
-        optimus |> Optimus.Help.help([], columns) |> put_lines
+        optimus |> Optimus.Help.help([], columns()) |> put_lines
         System.halt(0)
       {:help, subcommand_path} ->
-        optimus |> Optimus.Help.help(subcommand_path, columns) |> put_lines
+        optimus |> Optimus.Help.help(subcommand_path, columns()) |> put_lines
         System.halt(0)
     end
   end

--- a/test/optimus/formatable_help_test.exs
+++ b/test/optimus/formatable_help_test.exs
@@ -47,7 +47,7 @@ defmodule Optimus.FormatableHelpTest do
   end
 
   test "arg column help" do
-    help = Optimus.FormatableHelp.formatable_help("ARGS:", optimus.args, 80)
+    help = Optimus.FormatableHelp.formatable_help("ARGS:", optimus().args, 80)
 
     assert help == [
       "ARGS:",
@@ -65,7 +65,7 @@ defmodule Optimus.FormatableHelpTest do
   end
 
   test "arg simple help" do
-    help = Optimus.FormatableHelp.formatable_help("ARGS:", optimus.args, 10)
+    help = Optimus.FormatableHelp.formatable_help("ARGS:", optimus().args, 10)
     assert help == [
       "ARGS:",
       "",
@@ -77,7 +77,7 @@ defmodule Optimus.FormatableHelpTest do
 
 
   test "options column help" do
-    help = Optimus.FormatableHelp.formatable_help("OPTIONS:", optimus.options, 80)
+    help = Optimus.FormatableHelp.formatable_help("OPTIONS:", optimus().options, 80)
 
     assert help == [
       "OPTIONS:",
@@ -94,7 +94,7 @@ defmodule Optimus.FormatableHelpTest do
   end
 
   test "options simple help" do
-    help = Optimus.FormatableHelp.formatable_help("OPTIONS:", optimus.options, 10)
+    help = Optimus.FormatableHelp.formatable_help("OPTIONS:", optimus().options, 10)
 
     assert help == [
       "OPTIONS:",
@@ -106,7 +106,7 @@ defmodule Optimus.FormatableHelpTest do
 
 
   test "flag column help" do
-    help = Optimus.FormatableHelp.formatable_help("FLAGS:", optimus.flags, 80)
+    help = Optimus.FormatableHelp.formatable_help("FLAGS:", optimus().flags, 80)
 
     assert help == [
       "FLAGS:",
@@ -121,7 +121,7 @@ defmodule Optimus.FormatableHelpTest do
   end
 
   test "flag simple help" do
-    help = Optimus.FormatableHelp.formatable_help("FLAGS:", optimus.flags, 10)
+    help = Optimus.FormatableHelp.formatable_help("FLAGS:", optimus().flags, 10)
 
     assert help == [
       "FLAGS:",

--- a/test/optimus/help_test.exs
+++ b/test/optimus/help_test.exs
@@ -111,6 +111,6 @@ defmodule Optimus.HelpTest do
       "    subcommand        Help Help me if you can, I'm feeling down And I do        ",
       "                      appreciate you being 'round Help me get my feet back on   ",
       "                      the ground Won't you please, please help me?              ",
-      "" ] == Optimus.Help.help(optimus, [], 80)
+      "" ] == Optimus.Help.help(optimus(), [], 80)
   end
 end

--- a/test/optimus/usage_test.exs
+++ b/test/optimus/usage_test.exs
@@ -54,11 +54,11 @@ defmodule Optimus.UsageTest do
   end
 
   test "usage: main command" do
-    assert Usage.usage(optimus) == "awesome [--first-flag] [-s] [-o FIRST_OPTION] --second-option SECOND_OPTION FIRST [SECOND] [THIRD]"
+    assert Usage.usage(optimus()) == "awesome [--first-flag] [-s] [-o FIRST_OPTION] --second-option SECOND_OPTION FIRST [SECOND] [THIRD]"
   end
 
   test "usage: subcommand" do
-    assert Usage.usage(optimus, [:subcommand]) == "awesome subcommand [-f] [-o FIRST] FIRST"
+    assert Usage.usage(optimus(), [:subcommand]) == "awesome subcommand [-f] [-o FIRST] FIRST"
   end
 
 

--- a/test/optimus_test.exs
+++ b/test/optimus_test.exs
@@ -360,7 +360,7 @@ defmodule OptimusTest do
   ]
 
   test "test full valid config" do
-    assert {:ok, _} = Optimus.new(full_valid_config)
+    assert {:ok, _} = Optimus.new(full_valid_config())
   end
 
   test "parse: check format for arg" do
@@ -516,7 +516,7 @@ defmodule OptimusTest do
   end
 
   test "parse: full configuration" do
-    assert {:ok, optimus} = Optimus.new(full_valid_config)
+    assert {:ok, optimus} = Optimus.new(full_valid_config())
     command_line = ~w{123 AA -f --second-flag -s -o 123 --second-option DD -- thirdthird --fourth}
     assert {:ok, _} = Optimus.parse(optimus, command_line)
   end


### PR DESCRIPTION
Thank you for publishing a good argument parser for Elixir!

This PR fixes these warnings and makes Travis test with Elixir 1.4.0 in addition to 1.3.4:

```
# mix test    
Compiling 16 files (.ex)
warning: variable "columns" does not exist and is being expanded to "columns()", please use parentheses to remove the ambiguity or change the variable name
  lib/optimus.ex:106

warning: variable "columns" does not exist and is being expanded to "columns()", please use parentheses to remove the ambiguity or change the variable name
  lib/optimus.ex:109

Generated optimus app
warning: variable "optimus" does not exist and is being expanded to "optimus()", please use parentheses to remove the ambiguity or change the variable name
  test/optimus/usage_test.exs:57

warning: variable "optimus" does not exist and is being expanded to "optimus()", please use parentheses to remove the ambiguity or change the variable name
  test/optimus/usage_test.exs:61

warning: variable "optimus" does not exist and is being expanded to "optimus()", please use parentheses to remove the ambiguity or change the variable name
  test/optimus/help_test.exs:114

warning: variable "optimus" does not exist and is being expanded to "optimus()", please use parentheses to remove the ambiguity or change the variable name
  test/optimus/formatable_help_test.exs:50

warning: variable "optimus" does not exist and is being expanded to "optimus()", please use parentheses to remove the ambiguity or change the variable name
  test/optimus/formatable_help_test.exs:68

warning: variable "optimus" does not exist and is being expanded to "optimus()", please use parentheses to remove the ambiguity or change the variable name
  test/optimus/formatable_help_test.exs:80

warning: variable "optimus" does not exist and is being expanded to "optimus()", please use parentheses to remove the ambiguity or change the variable name
  test/optimus/formatable_help_test.exs:97

warning: variable "optimus" does not exist and is being expanded to "optimus()", please use parentheses to remove the ambiguity or change the variable name
  test/optimus/formatable_help_test.exs:109

warning: variable "optimus" does not exist and is being expanded to "optimus()", please use parentheses to remove the ambiguity or change the variable name
  test/optimus/formatable_help_test.exs:124

warning: variable "full_valid_config" does not exist and is being expanded to "full_valid_config()", please use parentheses to remove the ambiguity or change the variable name
  test/optimus_test.exs:363

warning: variable "full_valid_config" does not exist and is being expanded to "full_valid_config()", please use parentheses to remove the ambiguity or change the variable name
  test/optimus_test.exs:519

......................................................................

Finished in 0.2 seconds
70 tests, 0 failures

Randomized with seed 218440
```