### PR TITLE
Fixed typespec for input specs to handle subcommands

### DIFF
--- a/lib/optimus.ex
+++ b/lib/optimus.ex
@@ -80,6 +80,7 @@ defmodule Optimus do
           | {:args, [arg_spec_item]}
           | {:flags, [flag_spec_item]}
           | {:options, [option_spec_item]}
+          | {:subcommands, [{atom, spec}]}
   @type spec :: [spec_item]
 
   @type error :: String.t()


### PR DESCRIPTION
Originally, subcommands was not one of the specified spec_items, which meant that any call to Optimus.new which had :subcommands specified would result in a `fun/n has no local return" type error