### PR TITLE
Introduction of global and hiding flags and options

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ defmodule Statcalc do
           short: "-v",
           help: "Verbosity level",
           multiple: true,
+          global: true
         ],
       ],
       options: [

--- a/lib/optimus.ex
+++ b/lib/optimus.ex
@@ -57,6 +57,7 @@ defmodule Optimus do
           | {:help, String.t()}
           | {:multiple, boolean}
           | {:global, boolean}
+          | {:hide, boolean}
   @type flag_spec_item :: {name :: atom, [flag_spec_param]}
 
   @type option_spec_param ::
@@ -69,6 +70,7 @@ defmodule Optimus do
           | {:parser, parser}
           | {:default, any}
           | {:global, boolean}
+          | {:hide, boolean}
   @type option_spec_item :: {name :: atom, [option_spec_param]}
 
   @type spec_item ::

--- a/lib/optimus.ex
+++ b/lib/optimus.ex
@@ -56,6 +56,7 @@ defmodule Optimus do
           | {:long, String.t()}
           | {:help, String.t()}
           | {:multiple, boolean}
+          | {:global, boolean}
   @type flag_spec_item :: {name :: atom, [flag_spec_param]}
 
   @type option_spec_param ::
@@ -67,6 +68,7 @@ defmodule Optimus do
           | {:required, boolean}
           | {:parser, parser}
           | {:default, any}
+          | {:global, boolean}
   @type option_spec_item :: {name :: atom, [option_spec_param]}
 
   @type spec_item ::

--- a/lib/optimus/builder.ex
+++ b/lib/optimus/builder.ex
@@ -160,15 +160,15 @@ defmodule Optimus.Builder do
     end
   end
 
-  defp build_global_props(all_flags, all_options, global_props) do
-    global_flags = build_global_props_by_type(all_flags, :flags, global_props)
-    global_options = build_global_props_by_type(all_options, :flags, global_flags)
+  defp build_global_props(local_flags, local_options, global_props) do
+    global_flags = build_global_props_by_type(local_flags, :flags, global_props)
+    global_options = build_global_props_by_type(local_options, :options, global_props)
 
     {:ok, %{flags: global_flags, options: global_options}}
   end
 
-  defp build_global_props_by_type(all_props, type, global_props) do
-    all_props
+  defp build_global_props_by_type(local_props, type, global_props) do
+    local_props
     # Keep only global flags
     |> Enum.filter(& &1.global)
     # Hide global props on subcommands

--- a/lib/optimus/flag.ex
+++ b/lib/optimus/flag.ex
@@ -4,7 +4,8 @@ defmodule Optimus.Flag do
     :short,
     :long,
     :help,
-    :multiple
+    :multiple,
+    :global
   ]
 
   def new(spec) do

--- a/lib/optimus/flag.ex
+++ b/lib/optimus/flag.ex
@@ -5,7 +5,8 @@ defmodule Optimus.Flag do
     :long,
     :help,
     :multiple,
-    :global
+    :global,
+    :hide
   ]
 
   def new(spec) do

--- a/lib/optimus/flag/builder.ex
+++ b/lib/optimus/flag/builder.ex
@@ -15,8 +15,9 @@ defmodule Optimus.Flag.Builder do
          {:ok, long} <- build_long(props),
          {:ok, help} <- build_help(props),
          {:ok, multiple} <- build_multiple(props),
+         {:ok, global} <- build_global(props),
          {:ok, flag} <-
-           validate(%Flag{flag | short: short, long: long, help: help, multiple: multiple}),
+           validate(%Flag{flag | short: short, long: long, help: help, multiple: multiple, global: global}),
          do: {:ok, flag}
   end
 
@@ -42,6 +43,10 @@ defmodule Optimus.Flag.Builder do
 
   defp build_multiple(props) do
     PP.build_bool(:multiple, props[:multiple], false)
+  end
+
+  def build_global(props) do
+    PP.build_bool(:global, props[:global], false)
   end
 
   defp validate(flag) do

--- a/lib/optimus/flag/builder.ex
+++ b/lib/optimus/flag/builder.ex
@@ -16,8 +16,17 @@ defmodule Optimus.Flag.Builder do
          {:ok, help} <- build_help(props),
          {:ok, multiple} <- build_multiple(props),
          {:ok, global} <- build_global(props),
+         {:ok, hide} <- build_hide(props),
          {:ok, flag} <-
-           validate(%Flag{flag | short: short, long: long, help: help, multiple: multiple, global: global}),
+           validate(%Flag{
+             flag
+             | short: short,
+               long: long,
+               help: help,
+               multiple: multiple,
+               global: global,
+               hide: hide
+           }),
          do: {:ok, flag}
   end
 
@@ -47,6 +56,10 @@ defmodule Optimus.Flag.Builder do
 
   def build_global(props) do
     PP.build_bool(:global, props[:global], false)
+  end
+
+  def build_hide(props) do
+    PP.build_bool(:hide, props[:hide], false)
   end
 
   defp validate(flag) do

--- a/lib/optimus/formatable_help.ex
+++ b/lib/optimus/formatable_help.ex
@@ -15,9 +15,14 @@ defmodule Optimus.FormatableHelp do
     widths = get_column_widths(formatables, max_width)
 
     formatables
+    |> Enum.filter(&is_visible?(&1))
     |> Enum.map(&format_columns(widths, &1))
     |> Enum.concat()
     |> Enum.map(&Enum.join(&1))
+  end
+
+  defp is_visible?(formatable) do
+    not Map.get(formatable, :hide, false)
   end
 
   defp format_columns({:ok, widths}, formatable) do

--- a/lib/optimus/option.ex
+++ b/lib/optimus/option.ex
@@ -9,7 +9,8 @@ defmodule Optimus.Option do
     :required,
     :default,
     :parser,
-    :global
+    :global,
+    :hide
   ]
 
   def new(spec) do
@@ -28,9 +29,8 @@ defmodule Optimus.Option do
 
             {:error, reason} ->
               {:error,
-               "invalid value #{inspect(raw_value)} for #{Optimus.Format.format_in_error(option)} option: #{
-                 reason
-               }", rest}
+               "invalid value #{inspect(raw_value)} for #{Optimus.Format.format_in_error(option)} option: #{reason}",
+               rest}
           end
         else
           {:error, "multiple occurrences of option #{Optimus.Format.format_in_error(option)}",

--- a/lib/optimus/option.ex
+++ b/lib/optimus/option.ex
@@ -8,7 +8,8 @@ defmodule Optimus.Option do
     :multiple,
     :required,
     :default,
-    :parser
+    :parser,
+    :global
   ]
 
   def new(spec) do

--- a/lib/optimus/option/builder.ex
+++ b/lib/optimus/option/builder.ex
@@ -20,6 +20,7 @@ defmodule Optimus.Option.Builder do
          {:ok, default} <- build_default(props),
          {:ok, parser} <- build_parser(props),
          {:ok, global} <- build_global(props),
+         {:ok, hide} <- build_hide(props),
          {:ok, option} <-
            validate(%Option{
              option
@@ -31,7 +32,8 @@ defmodule Optimus.Option.Builder do
                required: required,
                default: default,
                parser: parser,
-               global: global
+               global: global,
+               hide: hide
            }),
          do: {:ok, option}
   end
@@ -79,6 +81,10 @@ defmodule Optimus.Option.Builder do
 
   defp build_global(props) do
     PP.build_bool(:global, props[:global], false)
+  end
+
+  defp build_hide(props) do
+    PP.build_bool(:hide, props[:hide], false)
   end
 
   defp validate(option) do

--- a/lib/optimus/option/builder.ex
+++ b/lib/optimus/option/builder.ex
@@ -19,6 +19,7 @@ defmodule Optimus.Option.Builder do
          {:ok, required} <- build_required(props),
          {:ok, default} <- build_default(props),
          {:ok, parser} <- build_parser(props),
+         {:ok, global} <- build_global(props),
          {:ok, option} <-
            validate(%Option{
              option
@@ -29,7 +30,8 @@ defmodule Optimus.Option.Builder do
                multiple: multiple,
                required: required,
                default: default,
-               parser: parser
+               parser: parser,
+               global: global
            }),
          do: {:ok, option}
   end
@@ -73,6 +75,10 @@ defmodule Optimus.Option.Builder do
 
   defp build_parser(props) do
     PP.build_parser(:parser, props[:parser])
+  end
+
+  defp build_global(props) do
+    PP.build_bool(:global, props[:global], false)
   end
 
   defp validate(option) do

--- a/lib/optimus/term.ex
+++ b/lib/optimus/term.ex
@@ -10,7 +10,9 @@ defmodule Optimus.Term do
             {width, _} -> {:ok, width}
             :error -> {:error, "invalid tputs result"}
           end
-        {error, _} -> {:error, "tputs error: #{error}"}
+
+        {error, _} ->
+          {:error, "tputs error: #{error}"}
       end
     rescue
       error in ErlangError ->

--- a/lib/optimus/usage.ex
+++ b/lib/optimus/usage.ex
@@ -1,8 +1,8 @@
 defmodule Optimus.Usage do
   def usage(optimus, subcommand_path \\ []) do
     {subcommand, subcommand_name} = Optimus.fetch_subcommand(optimus, subcommand_path)
-    flag_info = format_usage(subcommand.flags)
-    option_info = format_usage(subcommand.options)
+    flag_info = subcommand.flags |> Enum.filter(&(not &1.hide)) |> format_usage()
+    option_info = subcommand.options |> Enum.filter(&(not &1.hide)) |> format_usage()
     arg_info = format_arg_usage(subcommand)
     usage_parts = [subcommand_name, flag_info, option_info, arg_info]
 

--- a/test/optimus/term_test.exs
+++ b/test/optimus/term_test.exs
@@ -2,7 +2,7 @@ defmodule Optimus.TermTest do
   use ExUnit.Case
 
   test "width" do
-    unless System.get_env("CI")  do
+    unless System.get_env("CI") do
       assert {:ok, n} = Optimus.Term.width()
       assert is_integer(n)
       assert n > 0

--- a/test/optimus_test.exs
+++ b/test/optimus_test.exs
@@ -129,6 +129,20 @@ defmodule OptimusTest do
     assert true = app.options |> Enum.at(0) |> Map.get(:global)
   end
 
+  test "option: hide" do
+    assert {:ok, app} =
+             Optimus.new(
+               options: [
+                 first: [
+                   short: "-f",
+                   hide: true
+                 ]
+               ]
+             )
+
+    assert true = app.options |> Enum.at(0) |> Map.get(:hide)
+  end
+
   test "option: invalid short" do
     assert {:error, _} =
              Optimus.new(
@@ -346,6 +360,10 @@ defmodule OptimusTest do
           long: "third-flag",
           help: "Third flag",
           global: true
+        ],
+        fourth: [
+          long: "fourth-flag",
+          hide: true
         ]
       ],
       options: [
@@ -377,6 +395,13 @@ defmodule OptimusTest do
           help: "Third option",
           parser: :integer,
           global: true
+        ],
+        fourth: [
+          value_name: "FOURTH_OPTION",
+          long: "fourth-option",
+          help: "Fourth option",
+          parser: :integer,
+          hide: true
         ]
       ],
       subcommands: [
@@ -823,15 +848,54 @@ defmodule OptimusTest do
   end
 
   test "help" do
+    flags = [
+      is_visible_flag: [
+        long: "--is-visible-flag",
+        help: "Is visible flag"
+      ],
+      is_hidden_flag: [
+        long: "--is-hidden-flag",
+        hide: true,
+        help: "Is hidden flag"
+      ]
+    ]
+
+    options = [
+      is_visible_option: [
+        long: "--is-visible-option",
+        help: "Is visible option"
+      ],
+      is_hidden_option: [
+        long: "--is-hidden-option",
+        hide: true,
+        help: "Is hidden option"
+      ]
+    ]
+
     {:ok, optimus} =
       Optimus.new(
         subcommands: [
           sub: [
             name: "sub"
           ]
-        ]
+        ],
+        flags: flags,
+        options: options
       )
 
-    assert is_binary(Optimus.help(optimus))
+    help = Optimus.help(optimus)
+
+    assert is_binary(help)
+
+    # Visible
+    assert String.contains?(help, "--is-visible-flag")
+    assert String.contains?(help, "--is-visible-option")
+
+    # Hidden
+    assert not String.contains?(help, "--is-hidden-flag"), "Found hidden flag"
+    assert not String.contains?(help, "--is-hidden-option"), "Found hidden option"
+
+    assert String.contains?(help, "visible"), "Visible informations are missing"
+    assert not String.contains?(help, "hidden"), "Contains hidden informations"
   end
 end

--- a/test/optimus_test.exs
+++ b/test/optimus_test.exs
@@ -706,7 +706,7 @@ defmodule OptimusTest do
                ],
                flags: [
                  active: [short: "-a", global: true],
-                 slow: [short: "-s", global: true],
+                 slow: [short: "-s", global: true]
                ],
                subcommands: [
                  sub: [
@@ -716,6 +716,38 @@ defmodule OptimusTest do
              )
 
     assert {:ok, [:sub], parsed} = Optimus.parse(optimus, ~w{sub --verbose-level=4 -a})
+
+    assert 4 == parsed.options[:verbose_level]
+    assert true == parsed.flags[:active]
+    assert false == parsed.flags[:slow]
+  end
+
+  test "parse: deep nested command with global" do
+    assert {:ok, optimus} =
+             Optimus.new(
+               options: [
+                 verbose_level: [long: "--verbose-level", global: true, parser: :integer]
+               ],
+               flags: [
+                 active: [short: "-a", global: true]
+               ],
+               subcommands: [
+                 sub: [
+                   name: "sub",
+                   flags: [
+                     slow: [short: "-s", global: true]
+                   ],
+                   subcommands: [
+                     subsub: [
+                       name: "subsub"
+                     ]
+                   ]
+                 ]
+               ]
+             )
+
+    assert {:ok, [:sub, :subsub], parsed} =
+             Optimus.parse(optimus, ~w{sub subsub --verbose-level=4 -a})
 
     assert 4 == parsed.options[:verbose_level]
     assert true == parsed.flags[:active]


### PR DESCRIPTION
This PR should implement #11.

The current implementation merges global options/flags into all subcommands. On this way collisions can be detected (in case someone tries to redefine a property with the same short/long). In addition, every subcommand is a complete definition which makes parsing of global props easy.

Also I implemented hiding of properties in the same PR because it is used to hide global props in the subcommands. I know some CLI tools like kubectl that do not repeat global properties on the subcommands.